### PR TITLE
Ensure JS is run in the correct order for all browsers.

### DIFF
--- a/code/NocaptchaField.php
+++ b/code/NocaptchaField.php
@@ -83,11 +83,22 @@ class NocaptchaField extends FormField {
             user_error('You must configure Nocaptcha.site_key and Nocaptcha.secret_key, you can retrieve these at https://google.com/recaptcha', E_USER_ERROR);
         }
         
-        
-        Requirements::javascript('https://www.google.com/recaptcha/api.js?render=explicit&hl='.i18n::get_lang_from_locale(i18n::get_locale()).'&onload=noCaptchaFieldRender');
         Requirements::javascript(NOCAPTCHA_BASE.'/javascript/NocaptchaField.js');
-        Requirements::customScript("var _noCaptchaFields=_noCaptchaFields || [];_noCaptchaFields.push('".$this->getName()."');");
-        
+        Requirements::customScript(
+            "var _noCaptchaFields=_noCaptchaFields || [];_noCaptchaFields.push('".$this->getName()."');"
+        );
+        Requirements::customScript(
+            "(function() {\n" .
+            "    var gr = document.createElement('script'); gr.type = 'text/javascript'; gr.async = true;\n" .
+            "    gr.src = ('https:' == document.location.protocol ? 'https://www' : 'http://www') + " .
+            "'.google.com/recaptcha/api.js?render=explicit&hl=" .
+            i18n::get_lang_from_locale(i18n::get_locale()) .
+            "&onload=noCaptchaFieldRender';\n" .
+            "    var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(gr, s);\n" .
+            "})();\n",
+            'NocaptchaField-lib'
+        );
+
         return parent::Field($properties);
     }
     


### PR DESCRIPTION
On IE9, the JS is run in the wrong order on incorrect submissions via User Defined Forms, resulting in the NoCaptcha not appearing in this situation.

To replicate:
1.  Load a User Defined Form with a Spam Protection Field, with NoCaptcha set as the spam protector, in IE9.
2.  Fill in all other fields but leave the NoCaptcha blank.  Submit the form.

Current behaviour:
The Google script file is loaded and run, then the NocaptchaField.js script is processed.  The noCaptchaFieldRender function has not yet been defined, so the callback is not called by the Google file.

Expected behaviour:
The Google script is always run after the NocaptchaField.js script.  The noCaptchaFieldRender function is always defined, and the NoCaptcha is displayed.

This may also be an issue with other ways of using NoCaptcha, this pull request is a quick solution to my immediate issue.  There will be a better way of finding the NoCaptcha instances on the page and running grecaptcha.render on each of them.
