### PR TITLE
Update for 3.2 core and spamprotection compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require":
     {
-        "silverstripe/framework": ">=3.1.1,<3.2",
-        "silverstripe/spamprotection": ">=1.2.0",
+        "silverstripe/framework": "~3.1",
+        "silverstripe/spamprotection": "~2.0",
         "composer/installers": "*"
     },
     "support": {


### PR DESCRIPTION
Using ~3.1 of core allows for 3.2 core compat. Also tested, the module works with spamprotection ~2.0