### PR TITLE
Fix potential multiple activations of the same noCaptchaField

### DIFF
--- a/code/NocaptchaField.php
+++ b/code/NocaptchaField.php
@@ -108,7 +108,8 @@ class NocaptchaField extends FormField {
         
         Requirements::javascript(NOCAPTCHA_BASE.'/javascript/NocaptchaField.js');
         Requirements::customScript(
-            "var _noCaptchaFields=_noCaptchaFields || [];_noCaptchaFields.push('".$this->ID()."');"
+            "var _noCaptchaFields=_noCaptchaFields || [];_noCaptchaFields.push('".$this->ID()."');",
+            "NocaptchaField-" . $this->ID()
         );
         Requirements::customScript(
             "(function() {\n" .


### PR DESCRIPTION
The captcha field could potentially be activated multiple times (this happened for me with a custom form template), this can be fixed by using a unique id for the custom activation script.
Thank you!