### PR TITLE
Add support for  validator versions above 1.13.1

### DIFF
--- a/javascript/NocaptchaField.js
+++ b/javascript/NocaptchaField.js
@@ -18,6 +18,9 @@ function noCaptchaFieldRender() {
             
             if(typeof jQuery!='undefined' && typeof jQuery.fn.validate!='undefined') {
                 var formValidator=jQuery(form).data('validator');
+                if (!formValidator) {
+                    formValidator=jQuery(form).validate();
+                }
                 var superHandler=formValidator.settings.submitHandler;
                 formValidator.settings.submitHandler=function(form) {
                     grecaptcha.execute();


### PR DESCRIPTION
Checks if the formValidator is set and otherwise sets it by the method `validate()`.
This works from version 1.14 up to the latest (1.19)