### PR TITLE
ENHANCEMENT: Add ability to add exempt actions from recaptcha checks

### DIFF
--- a/javascript/NocaptchaField.js
+++ b/javascript/NocaptchaField.js
@@ -1,12 +1,20 @@
 var _noCaptchaFields=_noCaptchaFields || [];
+var _noCaptchaValidationExemptActions=_noCaptchaValidationExemptActions || [];
 
 function noCaptchaFieldRender() {
     var submitListener=function(e) {
+        // If the action is exempt from validation, skip any recaptcha checks
+        if (e.submitter &&
+            e.submitter.name &&
+            _noCaptchaValidationExemptActions.indexOf(e.submitter.name.substring(7)) > -1) {
+            return;
+        }
+
         e.preventDefault();
         var widgetID = e.target.querySelectorAll('.g-recaptcha')[0].getAttribute('data-widgetid');
         grecaptcha.execute(widgetID);
     };
-    
+
     var render = function(field) {
         var options={
             'sitekey': field.getAttribute('data-sitekey'),
@@ -15,12 +23,12 @@ function noCaptchaFieldRender() {
             'size': field.getAttribute('data-size'),
             'badge': field.getAttribute('data-badge'),
         };
-        
+
         //For the invisible captcha we need to setup some callback listeners
         if(field.getAttribute('data-size')=='invisible' && field.getAttribute('data-callback')==null) {
             var form=document.getElementById(field.getAttribute('data-form'));
             var superHandler=false;
-            
+
             if(typeof jQuery!='undefined' && typeof jQuery.fn.validate!='undefined') {
                 var formValidator=jQuery(form).data('validator');
                 if (!formValidator) {
@@ -40,7 +48,7 @@ function noCaptchaFieldRender() {
                     console.error('Could not attach event to the form');
                 }
             }
-            
+
             window['Nocaptcha-'+_noCaptchaFields[i]]=function() {
                 return new Promise(function(resolve, reject) {
                     if(typeof jQuery!='undefined' && typeof jQuery.fn.validate!='undefined' && superHandler) {
@@ -48,20 +56,20 @@ function noCaptchaFieldRender() {
                     }else {
                         form.submit();
                     }
-                    
+
                     resolve();
                 });
             };
-            
+
             options.callback = 'Nocaptcha-'+_noCaptchaFields[i];
         } else if (field.getAttribute('data-callback')) {
             options.callback = field.getAttribute('data-callback');
         }
-        
+
         var widget_id = grecaptcha.render(field, options);
         field.setAttribute("data-widgetid", widget_id);
     }
-    
+
     for(var i=0;i<_noCaptchaFields.length;i++) {
         render(document.getElementById('Nocaptcha-'+_noCaptchaFields[i]));
     }

--- a/src/Forms/NocaptchaField.php
+++ b/src/Forms/NocaptchaField.php
@@ -180,10 +180,16 @@ class NocaptchaField extends FormField {
             user_error('You must configure Nocaptcha.site_key and Nocaptcha.secret_key, you can retrieve these at https://google.com/recaptcha', E_USER_ERROR);
         }
 
+        $form = $this->getForm();
+
         if ($this->config()->get('recaptcha_version') == 2) {
+            $exemptActionsString = implode("' , '", $form->getValidationExemptActions());
+
             Requirements::javascript('undefinedoffset/silverstripe-nocaptcha:javascript/NocaptchaField.js');
             Requirements::customScript(
-                "var _noCaptchaFields=_noCaptchaFields || [];_noCaptchaFields.push('".$this->ID()."');",
+                "var _noCaptchaFields=_noCaptchaFields || [];_noCaptchaFields.push('".$this->ID()."');" .
+                "var _noCaptchaValidationExemptActions=_noCaptchaValidationExemptActions || [];" .
+                "_noCaptchaValidationExemptActions.push('" . $exemptActionsString . "');",
                 "NocaptchaField-" . $this->ID()
             );
             Requirements::customScript(
@@ -202,7 +208,6 @@ class NocaptchaField extends FormField {
             Requirements::javascript('undefinedoffset/silverstripe-nocaptcha:javascript/NocaptchaField_v3.js');
             Requirements::customCSS('.nocaptcha { display: none !important; }', self::class);
 
-            $form = $this->getForm();
             $helper = $form->getTemplateHelper();
             $id = $helper->generateFormID($form);
 


### PR DESCRIPTION
Ran into a scenario where a form could have actions such as "Cancel form" or "Save form" which may want to bypass validation in which case the user should not be presented with a recaptcha. 

There's also a secondary issue which this change allows a developer to bypass where there are multiple actions with `type="submit"`. e.g. if there was a Submit and Cancel action on the form and the user clicks the cancel action, normally a form would pass `action_cancel` in the FormData posted to the server. But because the NoCaptcha js calls preventDefault on the SubmitEvent and calls form.submit() via Javascript after recaptcha has passed, the SubmitEvent loses context of the action which was clicked. This leads Silverstripe just process the request [using the default action](https://github.com/silverstripe/silverstripe-framework/blob/4/src/Forms/FormRequestHandler.php#L166-L186). [More info here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/submit). 

> `<input>` with attribute type="submit" will not be submitted with the form when using HTMLFormElement.submit(), but it would be submitted when you do it with original HTML form submit.