### PR TITLE
CMS 6 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 Nocaptcha
 =================
 
-Adds a "spam protection" field to SilverStripe userforms using Google's
+Adds a "spam protection" field to Silverstripe userforms using Google's
 [reCAPTCHA](https://www.google.com/recaptcha) service.
 
 ## Requirements
-* SilverStripe ^4 | ^5
-* [SilverStripe Spam Protection
-  ^2 | ^3](https://github.com/silverstripe/silverstripe-spamprotection/)
+* Silverstripe framework ^6
+* [Silverstripe Spam Protection ^4](https://github.com/silverstripe/silverstripe-spamprotection/)
 * PHP CURL
 
 ## Installation
@@ -172,7 +171,7 @@ document.addEventListener("DOMContentLoaded", function(event) {
 ## Reporting an issue
 
 When you're reporting an issue please ensure you specify what version of
-SilverStripe you are using i.e. 3.1.3, 3.2beta, master etc. Also be sure to
+Silverstripe you are using i.e. 3.1.3, 3.2beta, master etc. Also be sure to
 include any JavaScript or PHP errors you receive, for PHP errors please ensure
 you include the full stack trace. Also please include how you produced the
 issue. You may also be asked to provide some of the classes to aid in

--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,8 @@
         }
     ],
     "require": {
-        "silverstripe/framework": "^4 | ^5",
-        "silverstripe/spamprotection": "^3 | ^4"
+        "silverstripe/framework": "^6",
+        "silverstripe/spamprotection": "^5"
     },
     "prefer-stable": true,
     "minimum-stability": "dev",
@@ -28,9 +28,6 @@
     "extra": {
         "expose": [
             "javascript"
-        ],
-		"branch-alias": {
-			"dev-master": "2.0.x-dev"
-		}
+        ]
     }
 }


### PR DESCRIPTION
Updates this module with compatibility for Silverstripe CMS 6.

Note that I haven't actually fully tested this - I just made sure there are no errors when rendering the form, I haven't submitted the form.

Normally I wouldn't submit a pull request without fully testing it but this was as far as I needed to go for my regression testing (just making sure `silverstripe/spamprotection` itself works) and I figured this either a) works as is or b) gets someone else 90% there.

Unfortunately this time around there is an API breaking change so we can't have `^4 || ^5 || ^6` constraint.